### PR TITLE
Update to 1.2.4

### DIFF
--- a/addons/amxmodx/data/lang/rt_library.txt
+++ b/addons/amxmodx/data/lang/rt_library.txt
@@ -1,5 +1,5 @@
 [en]
-RT_CHAT_TAG = ^4[RT]^t
+RT_CHAT_TAG = ^4[RT]
 RT_ANTI_FLOOD = ^3Wait before the next resurrection/planting
 RT_CHANGE_TEAM = ^3The player changed the team
 RT_ACTIVATOR_EXISTS = ^3The player is already being resurrected/planting
@@ -29,7 +29,7 @@ RT_DHUD_REVIVE2 = %n RESURRECTS YOU
 RT_DHUD_PLANTING = YOU'RE PLANTING %n
 
 [ru]
-RT_CHAT_TAG = ^4[RT]^t
+RT_CHAT_TAG = ^4[RT]
 RT_ANTI_FLOOD = ^3Подождите перед следующим воскрешением/минированием
 RT_CHANGE_TEAM = ^3Игрок изменил команду
 RT_ACTIVATOR_EXISTS = ^3Игрока уже воскрешают/минируют

--- a/addons/amxmodx/scripting/include/rt_api.inc
+++ b/addons/amxmodx/scripting/include/rt_api.inc
@@ -9,7 +9,7 @@
 #endif
 #define _rt_api_included
 
-public stock const VERSION[] = "1.2.3";
+public stock const VERSION[] = "1.2.4";
 public stock const AUTHORS[] = "DEV-CS.RU Community";
 
 /**
@@ -30,12 +30,12 @@ public stock const AUTHORS[] = "DEV-CS.RU Community";
 #endif
 
 /**
- * The maximum buffer size required to store a HUD/DHUD colors
+ * The maximum buffer size required to store a Hud/DHud colors
  */
 #define MAX_COLORS_LENGTH 16
 
 /**
- * The maximum buffer size required to store a HUD/DHUD coordinates
+ * The maximum buffer size required to store a Hud/DHud coordinates
  */
 #define MAX_COORDS_LENGTH 16
 
@@ -57,13 +57,14 @@ new const DEAD_BODY_CLASSNAME[] = "rt_corpse_empty";
  * Called after the activator starts resurrection/planting (on press USE - `E`)
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id who can be ressurected
+ * @param iPlayer        Player id who can be ressurected
  * @param iActivator     Player id who ressurect
  * @param eMode          MODE_REVIVE - started the resurrection, MODE_PLANT - started planting
  *
- * @noreturn
+ * @return               PLUGIN_CONTINUE to start resurrection/planting
+ *                       PLUGIN_HANDLED to stop resurrection/planting
  */
-forward rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode);
+forward rt_revive_start(const iEnt, const iPlayer, const iActivator, const Modes:eMode);
 
 /**
  * PreThink on resurrection/planting
@@ -71,15 +72,15 @@ forward rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMod
  * @note                 Timer can be 0.0
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id who can be ressurected
+ * @param iPlayer        Player id who can be ressurected
  * @param iActivator     Player id who ressurect
- * @param timer          Resurrection time
+ * @param fTimer         Resurrection time
  * @param eMode          MODE_REVIVE - the player continues to be resurrected, MODE_PLANT - the player continues to be planted
  *
  * @return               PLUGIN_CONTINUE to continue resurrection/planting
  *                       PLUGIN_HANDLED to stop resurrection/planting
  */
-forward rt_revive_loop_pre(const iEnt, const id, const iActivator, const Float:timer, Modes:eMode);
+forward rt_revive_loop_pre(const iEnt, const iPlayer, const iActivator, const Float:fTimer, Modes:eMode);
 
 /**
  * PostThink on resurrection/planting
@@ -87,80 +88,79 @@ forward rt_revive_loop_pre(const iEnt, const id, const iActivator, const Float:t
  * @note                 Timer can't be 0.0
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id who can be ressurected
+ * @param iPlayer        Player id who can be ressurected
  * @param iActivator     Player id who ressurect
- * @param timer          Resurrection time
+ * @param fTimer         Resurrection time
  * @param eMode          MODE_REVIVE - the player continues to be resurrected, MODE_PLANT - the player continues to be planted
  *
- * @return               PLUGIN_CONTINUE to continue resurrection/planting
- *                       PLUGIN_HANDLED to stop resurrection/planting
+ * @noreturn
  */
-forward rt_revive_loop_post(const iEnt, const id, const iActivator, const Float:timer, Modes:eMode);
+forward rt_revive_loop_post(const iEnt, const iPlayer, const iActivator, const Float:fTimer, Modes:eMode);
 
 /**
  * Called after the resurrection/planting is ending
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id who can be ressurected
+ * @param iPlayer        Player id who can be ressurected
  * @param iActivator     Player id who ressurect
  * @param eMode          MODE_REVIVE - the player was resurrected, MODE_PLANT - the player was planted
  *
  * @noreturn
  */
-forward rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode);
+forward rt_revive_end(const iEnt, const iPlayer, const iActivator, const Modes:eMode);
 
 /**
  * Called when the player has stopped resurrecting/planting
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id who can be ressurected or RT_NULLENT
+ * @param iPlayer        Player id who can be ressurected or RT_NULLENT
  * @param iActivator     Player id who ressurect or RT_NULLENT
  * @param eMode          MODE_REVIVE - stopped the resurrection, MODE_PLANT - stopped planting
  *
  * @noreturn
  */
-forward rt_revive_cancelled(const iEnt, const id, const iActivator, const Modes:eMode);
+forward rt_revive_cancelled(const iEnt, const iPlayer, const iActivator, const Modes:eMode);
 
 /**
  * Called before a corpse is created
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id whose corpse
+ * @param iPlayer        Player id whose corpse
  *
  * @return               PLUGIN_CONTINUE to continue the created of a corpse
  *                       PLUGIN_HANDLED to stop the created of a corpse
  */
-forward rt_creating_corpse_start(const iEnt, const id);
+forward rt_creating_corpse_start(const iEnt, const iPlayer);
 
 /**
  * Called after the creation of the corpse is completed
  *
  * @param iEnt           Corpse entity index
- * @param id             Player id whose corpse
- * @param vOrigin        Coordinates of the corpse
+ * @param iPlayer        Player id whose corpse
+ * @param fVecOrigin     Coordinates of the corpse
  *
  * @noreturn
  */
-forward rt_creating_corpse_end(const iEnt, const id, const vOrigin[3]);
+forward rt_creating_corpse_end(const iEnt, const iPlayer, const Float:fVecOrigin[3]);
 
 /**
  * Removal of corpses
  *
- * @param id             Player id whose corpse or 0 for all corpses
+ * @param iPlayer        Player id whose corpse or 0 for all corpses
  * @param szClassName    Entity classname
  *
  * @return               Player id who is resurrecting or 0
  */
-stock UTIL_RemoveCorpses(const id = 0, const szClassName[] = DEAD_BODY_CLASSNAME) {
+stock RemoveCorpses(const iPlayer = 0, const szClassName[] = DEAD_BODY_CLASSNAME) {
 	new iEnt = RT_NULLENT;
 	new iActivator, iOwner;
 
 	while((iEnt = rg_find_ent_by_class(iEnt, szClassName)) > 0) {
 		if(!is_nullent(iEnt)) {
-			if(id && (iOwner = get_entvar(iEnt, var_owner)) != id)
+			if(iPlayer && (iOwner = get_entvar(iEnt, var_owner)) != iPlayer)
 				continue;
 
-			if(id && iOwner == id)
+			if(iPlayer && iOwner == iPlayer)
 				iActivator = get_entvar(iEnt, var_iuser1);
 
 			set_entvar(iEnt, var_flags, FL_KILLME);
@@ -180,36 +180,36 @@ stock UTIL_RemoveCorpses(const id = 0, const szClassName[] = DEAD_BODY_CLASSNAME
  *
  * @param eForward       Forward type
  * @param iEnt           Corpse entity index
- * @param id             Player id whose corpse
+ * @param iPlayer        Player id whose corpse
  * @param iActivator     Player id who ressurect
  * @param eMode          MODE_REVIVE - stopped the resurrection, MODE_PLANT - stopped planting
  *
  * @noreturn
  */
-stock UTIL_ResetEntityThink(const eForward, const iEnt, const id, const iActivator, const Modes:eMode) {
+stock ResetCorpseThink(const eForward, const iEnt, iPlayer, iActivator, const Modes:eMode) {
 	if(!is_nullent(iEnt)) {
 		set_entvar(iEnt, var_nextthink, get_gametime() + 1.0);
 		set_entvar(iEnt, var_iuser1, 0);
 	}
 
-	new iPlayerEnt = is_user_connected(id) ? id : RT_NULLENT;
-	new iActivatorEnt = is_user_connected(iActivator) ? iActivator : RT_NULLENT;
+	iPlayer = is_user_connected(iPlayer) ? iPlayer : RT_NULLENT;
+	iActivator = is_user_connected(iActivator) ? iActivator : RT_NULLENT;
 
-	ExecuteForward(eForward, _, iEnt, iPlayerEnt, iActivatorEnt, eMode);
+	ExecuteForward(eForward, _, iEnt, iPlayer, iActivator, eMode);
 }
 
 /**
  * Notifying players in chat
  *
- * @param id             Player id or 0 to display to all clients
+ * @param iPlayer        Player id or 0 to display to all clients
  * @param iSender        Player id used as the message sender or color type
  * @param szFmtRules     Formatting rules
  *
  * @noreturn
  */
-stock UTIL_NotifyClient(const id, const iSender, const szFmtRules[], any:...) {
-	new szMessage[192];
-	SetGlobalTransTarget(id);
-	vformat(szMessage, charsmax(szMessage), szFmtRules, 4);
-	client_print_color(id, iSender, szMessage);
+stock NotifyClient(const iPlayer, const iSender, any:...) {
+	new szMessage[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(iPlayer);
+	vformat(szMessage, charsmax(szMessage), "%l", 3);
+	client_print_color(iPlayer, iSender, "%l %s", "RT_CHAT_TAG", szMessage);
 }

--- a/addons/amxmodx/scripting/rt_bonus.sma
+++ b/addons/amxmodx/scripting/rt_bonus.sma
@@ -63,7 +63,7 @@ public plugin_cfg() {
 	}
 }
 
-public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_end(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(eMode) {
 		case MODE_REVIVE: {
 			new Modes:iMode = Modes:get_entvar(iEnt, var_iuser3);
@@ -73,22 +73,22 @@ public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) 
 					rg_add_health_to_player(iActivator, g_eCvars[REVIVE_HEALTH]);
 
 				if(g_eCvars[HEALTH])
-					set_entvar(id, var_health, floatclamp(g_eCvars[HEALTH], 1.0, Float:get_entvar(id, var_max_health)));
+					set_entvar(iPlayer, var_health, floatclamp(g_eCvars[HEALTH], 1.0, Float:get_entvar(iPlayer, var_max_health)));
 
 				if(g_eCvars[ARMOR])
-					rg_set_user_armor(id, g_eCvars[ARMOR], ArmorType:g_eCvars[ARMOR_TYPE]);
+					rg_set_user_armor(iPlayer, g_eCvars[ARMOR], ArmorType:g_eCvars[ARMOR_TYPE]);
 
 				if(g_iWeapons > 0) {
-					rg_remove_all_items(id);
+					rg_remove_all_items(iPlayer);
 
 					for(new i; i <= g_iWeapons; i++) {
-						new iWeapon = rg_give_item(id, g_szWeapon[i]);
+						new iWeapon = rg_give_item(iPlayer, g_szWeapon[i]);
 
 						if(!is_nullent(iWeapon)) {
 							new WeaponIdType:iWeaponType = WeaponIdType:get_member(iWeapon, m_iId);
 
 							if(iWeaponType != WEAPON_KNIFE && iWeaponType != WEAPON_SHIELDGUN)
-								rg_set_user_bpammo(id, iWeaponType, rg_get_iteminfo(iWeapon, ItemInfo_iMaxAmmo1));
+								rg_set_user_bpammo(iPlayer, iWeaponType, rg_get_iteminfo(iWeapon, ItemInfo_iMaxAmmo1));
 						}
 					}
 				}
@@ -97,7 +97,7 @@ public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) 
 					ExecuteHamB(Ham_AddPoints, iActivator, g_eCvars[FRAGS], false);
 				
 				if(g_eCvars[NO_DEATHPOINT])
-					set_member(id, m_iDeaths, max(get_member(id, m_iDeaths) - 1, 0));
+					set_member(iPlayer, m_iDeaths, max(get_member(iPlayer, m_iDeaths) - 1, 0));
 			}
 		}
 		case MODE_PLANT: {
@@ -107,8 +107,8 @@ public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) 
 	}
 }
 
-stock rg_add_health_to_player(const id, const Float:flHealth) {
-	set_entvar(id, var_health, floatclamp(Float:get_entvar(id, var_health) + flHealth, 1.0, Float:get_entvar(id, var_max_health)));
+stock rg_add_health_to_player(const iPlayer, const Float:flHealth) {
+	set_entvar(iPlayer, var_health, floatclamp(Float:get_entvar(iPlayer, var_health) + flHealth, 1.0, Float:get_entvar(iPlayer, var_max_health)));
 }
 
 public CreateCvars() {

--- a/addons/amxmodx/scripting/rt_core.sma
+++ b/addons/amxmodx/scripting/rt_core.sma
@@ -29,12 +29,12 @@ enum Forwards {
 
 new g_eForwards[Forwards];
 
-new g_iPluginLoaded;
+new g_iPlantingPluginID;
 
-new Float:g_flLastUse[MAX_PLAYERS + 1], g_iTimeUntil[MAX_PLAYERS + 1];
+new Float:g_fLastUse[MAX_PLAYERS + 1], g_iTimeUntil[MAX_PLAYERS + 1];
 
-new Float:g_fSpawnOrigin[3];
-new HookChain:g_iGetPlayerSpawnSpot_HookChain;
+new Float:g_fVecSpawnOrigin[3];
+new HookChain:g_pHook_GetPlayerSpawnSpot;
 
 public plugin_precache() {
 	CreateCvars();
@@ -52,9 +52,8 @@ public plugin_init() {
 
 	RegisterHookChain(RG_CSGameRules_CleanUpMap, "CSGameRules_CleanUpMap_Post", true);
 	RegisterHookChain(RG_CBasePlayer_UseEmpty, "CBasePlayer_UseEmpty_Pre", false);
-	g_iGetPlayerSpawnSpot_HookChain = RegisterHookChain(RG_CSGameRules_GetPlayerSpawnSpot, "CSGameRules_GetPlayerSpawnSpot_Pre", false);
-	DisableHookChain(g_iGetPlayerSpawnSpot_HookChain);
-	RegisterHookChain(RG_CBasePlayer_Spawn, "CBasePlayer_Spawn_Pre", .post = 0);
+	DisableHookChain((g_pHook_GetPlayerSpawnSpot = RegisterHookChain(RG_CSGameRules_GetPlayerSpawnSpot, "CSGameRules_GetPlayerSpawnSpot_Pre", false)));
+	RegisterHookChain(RG_CBasePlayer_Spawn, "CBasePlayer_Spawn_Pre", false);
 
 	g_eForwards[ReviveStart] = CreateMultiForward("rt_revive_start", ET_STOP, FP_CELL, FP_CELL, FP_CELL, FP_CELL);
 	g_eForwards[ReviveLoop_Pre] = CreateMultiForward("rt_revive_loop_pre", ET_STOP, FP_CELL, FP_CELL, FP_CELL, FP_FLOAT, FP_CELL);
@@ -64,30 +63,17 @@ public plugin_init() {
 	g_eForwards[CreatingCorpseStart] = CreateMultiForward("rt_creating_corpse_start", ET_STOP, FP_CELL, FP_CELL);
 	g_eForwards[CreatingCorpseEnd] = CreateMultiForward("rt_creating_corpse_end", ET_IGNORE, FP_CELL, FP_CELL, FP_ARRAY);
 
-	g_iPluginLoaded = is_plugin_loaded("rt_planting.amxx", true);
+	g_iPlantingPluginID = is_plugin_loaded("rt_planting.amxx", true);
 }
 
-public CBasePlayer_Spawn_Pre(id) {
-	PlayerSpawnOrDisconnect(id);
-}
+public client_disconnected(iPlayer) {
+	g_fLastUse[iPlayer] = 0.0;
 
-public client_disconnected(id) {
-	g_flLastUse[id] = 0.0;
-
-	PlayerSpawnOrDisconnect(id);
-}
-
-PlayerSpawnOrDisconnect(id) {
-	new iActivator = UTIL_RemoveCorpses(id, DEAD_BODY_CLASSNAME);
-
-	if(is_user_connected(iActivator)) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_DISCONNECTED");
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], RT_NULLENT, id, iActivator, MODE_NONE);
-	}
+	PlayerSpawnOrDisconnect(iPlayer);
 }
 
 public CSGameRules_CleanUpMap_Post() {
-	UTIL_RemoveCorpses(0, DEAD_BODY_CLASSNAME);
+	RemoveCorpses(0, DEAD_BODY_CLASSNAME);
 }
 
 public CBasePlayer_UseEmpty_Pre(const iActivator) {
@@ -96,14 +82,14 @@ public CBasePlayer_UseEmpty_Pre(const iActivator) {
 
 	new iEnt = RT_NULLENT;
 
-	new Float:vPlOrigin[3], Float:vEntOrigin[3];
-	get_entvar(iActivator, var_origin, vPlOrigin);
+	new Float:fVecPlOrigin[3], Float:fVecEntOrigin[3];
+	get_entvar(iActivator, var_origin, fVecPlOrigin);
 
 	while((iEnt = rg_find_ent_by_class(iEnt, DEAD_BODY_CLASSNAME)) > 0) {
 		if(!is_nullent(iEnt)) {
-			get_entvar(iEnt, var_vuser4, vEntOrigin);
+			get_entvar(iEnt, var_vuser4, fVecEntOrigin);
 
-			if(ExecuteHam(Ham_FVecInViewCone, iActivator, vEntOrigin) && vector_distance(vPlOrigin, vEntOrigin) < g_eCvars[SEARCH_RADIUS]) {
+			if(ExecuteHam(Ham_FVecInViewCone, iActivator, fVecEntOrigin) && vector_distance(fVecPlOrigin, fVecEntOrigin) < g_eCvars[SEARCH_RADIUS]) {
 				Corpse_Use(iEnt, iActivator);
 				return;
 			}
@@ -112,26 +98,30 @@ public CBasePlayer_UseEmpty_Pre(const iActivator) {
 }
 
 public CSGameRules_GetPlayerSpawnSpot_Pre(const iPlayer) {
-	DisableHookChain(g_iGetPlayerSpawnSpot_HookChain);
+	DisableHookChain(g_pHook_GetPlayerSpawnSpot);
 
 	set_entvar(iPlayer, var_flags, get_entvar(iPlayer, var_flags) | FL_DUCKING);
 
 	set_entvar(iPlayer, var_velocity, NULL_VECTOR);
 	set_entvar(iPlayer, var_v_angle, NULL_VECTOR);
 
-	new Float:fAngles[3];
-	get_entvar(iPlayer, var_angles, fAngles);
-	fAngles[0] = fAngles[2] = 0.0;
-	set_entvar(iPlayer, var_angles, fAngles);
+	new Float:fVecAngles[3];
+	get_entvar(iPlayer, var_angles, fVecAngles);
+	fVecAngles[0] = fVecAngles[2] = 0.0;
+	set_entvar(iPlayer, var_angles, fVecAngles);
 
 	set_entvar(iPlayer, var_punchangle, NULL_VECTOR);
 	set_entvar(iPlayer, var_fixangle, 1);
 
 	engfunc(EngFunc_SetSize, iPlayer, Float:{-16.000000, -16.000000, -18.000000}, Float:{16.000000, 16.000000, 32.000000});
-	engfunc(EngFunc_SetOrigin, iPlayer, g_fSpawnOrigin);
+	engfunc(EngFunc_SetOrigin, iPlayer, g_fVecSpawnOrigin);
 
 	SetHookChainReturn(ATYPE_INTEGER, RT_NULLENT);
 	return HC_SUPERCEDE;
+}
+
+public CBasePlayer_Spawn_Pre(const iPlayer) {
+	PlayerSpawnOrDisconnect(iPlayer);
 }
 
 public Corpse_Use(const iEnt, const iActivator) {
@@ -139,29 +129,29 @@ public Corpse_Use(const iEnt, const iActivator) {
 		return;
 
 	new iPlayer = get_entvar(iEnt, var_owner);
-	new TeamName:iActTeam = TeamName:get_member(iActivator, m_iTeam);
 	new TeamName:iPlTeam = TeamName:get_member(iPlayer, m_iTeam);
+	new TeamName:iActTeam = TeamName:get_member(iActivator, m_iTeam);
 	new TeamName:iEntTeam = TeamName:get_entvar(iEnt, var_team);
 	new Modes:eCurrentMode = (iActTeam == iPlTeam) ? MODE_REVIVE : MODE_PLANT;
 
-	if(g_iPluginLoaded == INVALID_PLUGIN_ID && eCurrentMode == MODE_PLANT)
+	if(g_iPlantingPluginID == INVALID_PLUGIN_ID && eCurrentMode == MODE_PLANT)
 		return;
 
 	if(iActTeam == TEAM_SPECTATOR || iPlTeam == TEAM_SPECTATOR)
 		return;
 
 	if(iEntTeam != iPlTeam) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_CHANGE_TEAM");
+		NotifyClient(iActivator, print_team_red, "RT_CHANGE_TEAM");
 		return;
 	}
 
 	if(get_entvar(iEnt, var_iuser1)) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_ACTIVATOR_EXISTS");
+		NotifyClient(iActivator, print_team_red, "RT_ACTIVATOR_EXISTS");
 		return;
 	}
 
 	if(!is_user_alive(iActivator)) {
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+		ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 		return;
 	}
 
@@ -169,29 +159,29 @@ public Corpse_Use(const iEnt, const iActivator) {
 	ExecuteForward(g_eForwards[ReviveStart], fwRet, iEnt, iPlayer, iActivator, eCurrentMode);
 
 	if(fwRet == PLUGIN_HANDLED) {
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+		ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 		return;
 	}
 
-	new Float:flGameTime = get_gametime();
+	new Float:fGameTime = get_gametime();
 
-	if(g_flLastUse[iActivator] > flGameTime) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_ANTI_FLOOD");
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+	if(g_fLastUse[iActivator] > fGameTime) {
+		NotifyClient(iActivator, print_team_red, "RT_ANTI_FLOOD");
+		ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 		return;
 	}
 
-	g_flLastUse[iActivator] = flGameTime + g_eCvars[ANTIFLOOD_TIME];
+	g_fLastUse[iActivator] = fGameTime + g_eCvars[ANTIFLOOD_TIME];
 
-	UTIL_NotifyClient(iActivator, print_team_blue, "%l%l", "RT_CHAT_TAG", eCurrentMode == MODE_REVIVE ? "RT_TIMER_REVIVE" : "RT_TIMER_PLANT", iPlayer);
+	NotifyClient(iActivator, print_team_blue, eCurrentMode == MODE_REVIVE ? "RT_TIMER_REVIVE" : "RT_TIMER_PLANT", iPlayer);
 
 	g_iTimeUntil[iActivator] = 0;
 
 	set_entvar(iEnt, var_iuser1, iActivator);
 	set_entvar(iEnt, var_iuser2, eCurrentMode);
-	set_entvar(iEnt, var_fuser1, flGameTime + g_eCvars[REVIVE_TIME]);
+	set_entvar(iEnt, var_fuser1, fGameTime + g_eCvars[REVIVE_TIME]);
 	set_entvar(iEnt, var_fuser3, g_eCvars[REVIVE_TIME]);
-	set_entvar(iEnt, var_nextthink, flGameTime + 0.1);
+	set_entvar(iEnt, var_nextthink, fGameTime + 0.1);
 }
 
 public Corpse_Think(const iEnt) {
@@ -200,15 +190,15 @@ public Corpse_Think(const iEnt) {
 
 	new iPlayer = get_entvar(iEnt, var_owner);
 	new iActivator = get_entvar(iEnt, var_iuser1);
-	new Float:flGameTime = get_gametime();
+	new Float:fGameTime = get_gametime();
 
 	if(!iActivator) {
-		if(g_eCvars[CORPSE_TIME] && Float:get_entvar(iEnt, var_fuser4) < flGameTime) {
-			UTIL_RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
+		if(g_eCvars[CORPSE_TIME] && Float:get_entvar(iEnt, var_fuser4) < fGameTime) {
+			RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
 			return;
 		}
 
-		set_entvar(iEnt, var_nextthink, flGameTime + 1.0);
+		set_entvar(iEnt, var_nextthink, fGameTime + 1.0);
 		return;
 	}
 
@@ -217,61 +207,61 @@ public Corpse_Think(const iEnt) {
 	new Modes:eCurrentMode = Modes:get_entvar(iEnt, var_iuser2);
 
 	if(iEntTeam != iPlTeam) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_CHANGE_TEAM");
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+		NotifyClient(iActivator, print_team_red, "RT_CHANGE_TEAM");
+		ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 		return;
 	}
 
 	if(~get_entvar(iActivator, var_button) & IN_USE) {
-		UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", eCurrentMode == MODE_REVIVE ? "RT_CANCELLED_REVIVE" : "RT_CANCELLED_PLANT");
-		UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+		NotifyClient(iActivator, print_team_red, eCurrentMode == MODE_REVIVE ? "RT_CANCELLED_REVIVE" : "RT_CANCELLED_PLANT");
+		ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 		return;
 	}
 
-	new Float:flTimeUntil[2];
-	flTimeUntil[0] = Float:get_entvar(iEnt, var_fuser1);
-	flTimeUntil[1] = Float:get_entvar(iEnt, var_fuser3);
+	new Float:fTimeUntil[2];
+	fTimeUntil[0] = Float:get_entvar(iEnt, var_fuser1);
+	fTimeUntil[1] = Float:get_entvar(iEnt, var_fuser3);
 
 	g_iTimeUntil[iActivator]++;
 
 	if(g_iTimeUntil[iActivator] == 10 || g_eCvars[FORCE_FWD_MODE]) {
-		flTimeUntil[1] -= 1.0;
+		fTimeUntil[1] -= 1.0;
 
 		if(!is_user_alive(iActivator)) {
-			UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+			ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 			return;
 		}
 
 		new fwRet;
-		ExecuteForward(g_eForwards[ReviveLoop_Pre], fwRet, iEnt, iPlayer, iActivator, flTimeUntil[1], eCurrentMode);
+		ExecuteForward(g_eForwards[ReviveLoop_Pre], fwRet, iEnt, iPlayer, iActivator, fTimeUntil[1], eCurrentMode);
 
 		if(fwRet == PLUGIN_HANDLED) {
-			UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+			ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 			return;
 		}
 	}
 
-	if(flGameTime > flTimeUntil[0]) {
+	if(fGameTime > fTimeUntil[0]) {
 		new Modes:iMode = Modes:get_entvar(iEnt, var_iuser3);
 
 		if(eCurrentMode == MODE_REVIVE && iMode != MODE_PLANT) {
-			UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_REVIVE", iPlayer);
-			UTIL_NotifyClient(iPlayer, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_REVIVED", iActivator);
+			NotifyClient(iActivator, print_team_red, "RT_REVIVE", iPlayer);
+			NotifyClient(iPlayer, print_team_red, "RT_REVIVED", iActivator);
 
-			get_entvar(iActivator, var_origin, g_fSpawnOrigin);
+			get_entvar(iActivator, var_origin, g_fVecSpawnOrigin);
 
-			UTIL_RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
+			RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
 
-			EnableHookChain(g_iGetPlayerSpawnSpot_HookChain);
+			EnableHookChain(g_pHook_GetPlayerSpawnSpot);
 			rg_round_respawn(iPlayer);
-			DisableHookChain(g_iGetPlayerSpawnSpot_HookChain);
+			DisableHookChain(g_pHook_GetPlayerSpawnSpot);
 
 			if(is_user_alive(iPlayer))
-				engfunc(EngFunc_SetOrigin, iPlayer, g_fSpawnOrigin);
+				engfunc(EngFunc_SetOrigin, iPlayer, g_fVecSpawnOrigin);
 		}
 
 		if(!is_user_alive(iActivator)) {
-			UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+			ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 			return;
 		}
 
@@ -282,17 +272,17 @@ public Corpse_Think(const iEnt) {
 
 	if(g_iTimeUntil[iActivator] == 10 || g_eCvars[FORCE_FWD_MODE]) {
 		if(!is_user_alive(iActivator)) {
-			UTIL_ResetEntityThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
+			ResetCorpseThink(g_eForwards[ReviveCancelled], iEnt, iPlayer, iActivator, eCurrentMode);
 			return;
 		}
 
-		ExecuteForward(g_eForwards[ReviveLoop_Post], _, iEnt, iPlayer, iActivator, flTimeUntil[1], eCurrentMode);
+		ExecuteForward(g_eForwards[ReviveLoop_Post], _, iEnt, iPlayer, iActivator, fTimeUntil[1], eCurrentMode);
 
 		g_iTimeUntil[iActivator] = 0;
 	}
 
-	set_entvar(iEnt, var_fuser3, flTimeUntil[1]);
-	set_entvar(iEnt, var_nextthink, flGameTime + 0.1);
+	set_entvar(iEnt, var_fuser3, fTimeUntil[1]);
+	set_entvar(iEnt, var_nextthink, fGameTime + 0.1);
 }
 
 public MessageHook_ClCorpse() {
@@ -338,16 +328,16 @@ public MessageHook_ClCorpse() {
 	set_entvar(iEnt, var_owner, iPlayer);
 	set_entvar(iEnt, var_team, iPlTeam);
 
-	new Float:fOrigin[3];
-	get_entvar(iPlayer, var_origin, fOrigin);
-	engfunc(EngFunc_SetOrigin, iEnt, fOrigin);
+	new Float:fVecOrigin[3];
+	get_entvar(iPlayer, var_origin, fVecOrigin);
+	engfunc(EngFunc_SetOrigin, iEnt, fVecOrigin);
 
-	new Float:fAngles[3];
-	get_entvar(iPlayer, var_angles, fAngles);
-	set_entvar(iEnt, var_angles, fAngles);
+	new Float:fVecAngles[3];
+	get_entvar(iPlayer, var_angles, fVecAngles);
+	set_entvar(iEnt, var_angles, fVecAngles);
 
-	engfunc(EngFunc_GetBonePosition, iEnt, 2, fOrigin, fAngles);
-	set_entvar(iEnt, var_vuser4, fOrigin);
+	engfunc(EngFunc_GetBonePosition, iEnt, 2, fVecOrigin, fVecAngles);
+	set_entvar(iEnt, var_vuser4, fVecOrigin);
 
 	set_entvar(iEnt, var_fuser2, g_eCvars[SEARCH_RADIUS]);
 
@@ -357,16 +347,20 @@ public MessageHook_ClCorpse() {
 	if(g_eCvars[CORPSE_TIME])
 		set_entvar(iEnt, var_fuser4, get_gametime() + g_eCvars[CORPSE_TIME]);
 
-	new szOriginData[3];
+	fVecOrigin[2] += 20.0;
 
-	for(new i; i < 3; i++)
-		szOriginData[i] = floatround(fOrigin[i]);
-
-	szOriginData[2] += 20;
-
-	ExecuteForward(g_eForwards[CreatingCorpseEnd], _, iEnt, iPlayer, PrepareArray(szOriginData, sizeof(szOriginData)));
+	ExecuteForward(g_eForwards[CreatingCorpseEnd], _, iEnt, iPlayer, PrepareArray(_:fVecOrigin, sizeof(fVecOrigin)));
 
 	return PLUGIN_HANDLED;
+}
+
+stock PlayerSpawnOrDisconnect(const iPlayer) {
+	new iActivator = RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
+
+	if(is_user_connected(iActivator))
+		NotifyClient(iActivator, print_team_red, "RT_DISCONNECTED");
+
+	ResetCorpseThink(g_eForwards[ReviveCancelled], RT_NULLENT, iPlayer, iActivator, MODE_NONE);
 }
 
 public CreateCvars() {

--- a/addons/amxmodx/scripting/rt_effects.sma
+++ b/addons/amxmodx/scripting/rt_effects.sma
@@ -96,61 +96,56 @@ public AddToFullPack_Pre(es, e, ent, host, flags, player, pSet) {
 	return FMRES_IGNORED;
 }
 
-public rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_start(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(eMode) {
 		case MODE_REVIVE: {
 			if(g_eCvars[SPECTATOR]) {
-				rg_internal_cmd(id, "specmode", "4");
-				set_entvar(id, var_iuser2, iActivator);
-				set_member(id, m_hObserverTarget, iActivator);
-				set_member(id, m_flNextObserverInput, get_gametime() + 1.25);
+				rg_internal_cmd(iPlayer, "specmode", "4");
+				set_entvar(iPlayer, var_iuser2, iActivator);
+				set_member(iPlayer, m_hObserverTarget, iActivator);
+				set_member(iPlayer, m_flNextObserverInput, get_gametime() + 1.25);
 			}
 
 			if(g_eCvars[NOTIFY_DHUD]) {
-				DisplayDHUDMessage(iActivator, "%l", eMode, "RT_DHUD_REVIVE", id);
-				DisplayDHUDMessage(id, "%l", eMode, "RT_DHUD_REVIVE2", iActivator);
+				DisplayDHudMessage(iActivator, eMode, "RT_DHUD_REVIVE", iPlayer);
+				DisplayDHudMessage(iPlayer, eMode, "RT_DHUD_REVIVE2", iActivator);
 			}
 		}
 		case MODE_PLANT: {
 			if(g_eCvars[NOTIFY_DHUD])
-				DisplayDHUDMessage(iActivator, "%l", eMode, "RT_DHUD_PLANTING", id);
+				DisplayDHudMessage(iActivator, eMode, "RT_DHUD_PLANTING", iPlayer);
 		}
 	}
 }
 
-public rt_revive_cancelled(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_cancelled(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	if(g_eCvars[NOTIFY_DHUD]) {
 		if(iActivator != RT_NULLENT)
-			ClearDHUDMessages(iActivator);
+			ClearDHudMessages(iActivator);
 
-		if(id != RT_NULLENT)
-			ClearDHUDMessages(id);
+		if(iPlayer != RT_NULLENT)
+			ClearDHudMessages(iPlayer);
 	}
 }
 
-public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_end(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	if(g_eCvars[NOTIFY_DHUD]) {
-		ClearDHUDMessages(iActivator);
-		ClearDHUDMessages(id);
+		ClearDHudMessages(iActivator);
+		ClearDHudMessages(iPlayer);
 	}
 }
 
-public rt_creating_corpse_end(const iEnt, const id, const origin[3]) {
+public rt_creating_corpse_end(const iEnt, const iPlayer, const Float:fVecOrigin[3]) {
 	if(g_eCvars[CORPSE_SPRITE][0] == EOS)
 		return;
 
 	new iEntSprite = rg_create_entity("info_target");
 
-	new Float:fOrigin[3];
-
-	for(new i; i < 3; i++)
-		fOrigin[i] = float(origin[i]);
-
-	engfunc(EngFunc_SetOrigin, iEntSprite, fOrigin);
+	engfunc(EngFunc_SetOrigin, iEntSprite, fVecOrigin);
 	engfunc(EngFunc_SetModel, iEntSprite, g_eCvars[CORPSE_SPRITE]);
 
 	set_entvar(iEntSprite, var_classname, CORPSE_SPRITE_CLASSNAME);
-	set_entvar(iEntSprite, var_owner, id);
+	set_entvar(iEntSprite, var_owner, iPlayer);
 	set_entvar(iEntSprite, var_iuser1, iEnt);
 	set_entvar(iEntSprite, var_team, TeamName:get_entvar(iEnt, var_team));
 	set_entvar(iEntSprite, var_scale, g_eCvars[SPRITE_SCALE]);
@@ -160,31 +155,31 @@ public rt_creating_corpse_end(const iEnt, const id, const origin[3]) {
 	set_entvar(iEntSprite, var_renderamt, 255.0);
 	set_entvar(iEntSprite, var_nextthink, get_gametime() + 0.1);
 
-	SetThink(iEntSprite, "Corpse_Sprite_Think");
+	SetThink(iEntSprite, "CorpseSprite_Think");
 }
 
-public Corpse_Sprite_Think(const iEnt) {
+public CorpseSprite_Think(const iEnt) {
 	if(is_nullent(get_entvar(iEnt, var_iuser1))) {
-		UTIL_RemoveCorpses(get_entvar(iEnt, var_owner), CORPSE_SPRITE_CLASSNAME);
+		RemoveCorpses(get_entvar(iEnt, var_owner), CORPSE_SPRITE_CLASSNAME);
 		return;
 	}
 
 	set_entvar(iEnt, var_nextthink, get_gametime() + 0.1);
 }
 
-stock DisplayDHUDMessage(const id, const szFmtRules[], const Modes:eMode, any:...) {
-	new szMessage[MAX_MESSAGE_LENGTH];
-	SetGlobalTransTarget(id);
-	vformat(szMessage, charsmax(szMessage), szFmtRules, 4);
+stock DisplayDHudMessage(const iPlayer, const Modes:eMode, any:...) {
+	new szMessage[128];
+	SetGlobalTransTarget(iPlayer);
+	vformat(szMessage, charsmax(szMessage), "%l", 3);
 
 	set_dhudmessage(g_eDHudData[eMode][COLOR_R], g_eDHudData[eMode][COLOR_G], g_eDHudData[eMode][COLOR_B],
 	g_eDHudData[eMode][COORD_X], g_eDHudData[eMode][COORD_Y], .holdtime = g_fTime);
-	show_dhudmessage(id, szMessage);
+	show_dhudmessage(iPlayer, szMessage);
 }
 
-stock ClearDHUDMessages(const id, const iChannel = 8) {
+stock ClearDHudMessages(const iPlayer, const iChannel = 8) {
 	for(new i; i < iChannel; i++)
-		show_dhudmessage(id, "");
+		show_dhudmessage(iPlayer, "");
 }
 
 public CreateCvars() {

--- a/addons/amxmodx/scripting/rt_planting.sma
+++ b/addons/amxmodx/scripting/rt_planting.sma
@@ -45,21 +45,21 @@ public CSGameRules_CleanUpMap_Post() {
 	arrayset(g_ePlayerData[0][_:0], 0, sizeof(g_ePlayerData) * sizeof(g_ePlayerData[]));
 }
 
-public client_disconnected(id) {
-	g_ePlayerData[id][PLANTING_COUNT] = 0;
+public client_disconnected(iPlayer) {
+	g_ePlayerData[iPlayer][PLANTING_COUNT] = 0;
 }
 
-public rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_start(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	new Modes:iMode = Modes:get_entvar(iEnt, var_iuser3);
 	
 	if(eMode == MODE_PLANT) {
 		if(g_ePlayerData[iActivator][PLANTING_COUNT] >= g_eCvars[MAX_PLANTING]) {
-			UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_PLANTING_COUNT");
+			NotifyClient(iActivator, print_team_red, "RT_PLANTING_COUNT");
 			return PLUGIN_HANDLED;
 		}
 
 		if(iMode == MODE_PLANT) {
-			UTIL_NotifyClient(iActivator, print_team_red, "%l%l", "RT_CHAT_TAG", "RT_IS_PLANTED");
+			NotifyClient(iActivator, print_team_red, "RT_IS_PLANTED", iPlayer);
 			return PLUGIN_HANDLED;
 		}
 	}
@@ -67,25 +67,25 @@ public rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode
 	return PLUGIN_CONTINUE;
 }
 
-public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_end(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(eMode) {
 		case MODE_REVIVE: {
 			new Modes:iMode = Modes:get_entvar(iEnt, var_iuser3);
 
 			if(iMode == MODE_PLANT) {
-				new Float:vOrigin[3];
-				get_entvar(iActivator, var_origin, vOrigin);
-				UTIL_MakeExplosionEffects(vOrigin);
+				new Float:fVecOrigin[3];
+				get_entvar(iActivator, var_origin, fVecOrigin);
+				MakeExplosionEffects(fVecOrigin);
 				
 				new iPlanter = get_entvar(iEnt, var_iuser4);
 				
-				for(new iVictim = 1, Float:fReduceDamage, Float:vecEnd[3]; iVictim <= MaxClients; iVictim++) {
-					if(!is_user_alive(iVictim) || TeamName:get_member(iVictim, m_iTeam) != TeamName:get_member(id, m_iTeam))
+				for(new iVictim = 1, Float:fReduceDamage, Float:fVecEnd[3]; iVictim <= MaxClients; iVictim++) {
+					if(!is_user_alive(iVictim) || TeamName:get_member(iVictim, m_iTeam) != TeamName:get_member(iPlayer, m_iTeam))
 						continue;
 					
-					get_entvar(iVictim, var_origin, vecEnd);
+					get_entvar(iVictim, var_origin, fVecEnd);
 
-					if((fReduceDamage = (g_eCvars[DAMAGE] - vector_distance(vOrigin, vecEnd) * (g_eCvars[DAMAGE] / g_eCvars[RADIUS]))) < 1.0)
+					if((fReduceDamage = (g_eCvars[DAMAGE] - vector_distance(fVecOrigin, fVecEnd) * (g_eCvars[DAMAGE] / g_eCvars[RADIUS]))) < 1.0)
 						continue;
 					
 					set_member(iVictim, m_LastHitGroup, HITGROUP_GENERIC);
@@ -93,11 +93,11 @@ public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) 
 					ExecuteHamB(Ham_TakeDamage, iVictim, iEnt, iPlanter, fReduceDamage, DMG_GRENADE | DMG_ALWAYSGIB);
 				}
 
-				UTIL_RemoveCorpses(id, DEAD_BODY_CLASSNAME);
+				RemoveCorpses(iPlayer, DEAD_BODY_CLASSNAME);
 			}
 		}
 		case MODE_PLANT: {
-			UTIL_NotifyClient(iActivator, print_team_blue, "%l%l", "RT_CHAT_TAG", "RT_PLANTING", id);
+			NotifyClient(iActivator, print_team_blue, "RT_PLANTING", iPlayer);
 			
 			g_ePlayerData[iActivator][PLANTING_COUNT]++;
 
@@ -108,23 +108,23 @@ public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) 
 	}
 }
 
-stock UTIL_MakeExplosionEffects(const Float:vecOrigin[3]) {
-	message_begin_f(MSG_PAS, SVC_TEMPENTITY, vecOrigin);
+stock MakeExplosionEffects(const Float:fVecOrigin[3]) {
+	message_begin_f(MSG_PAS, SVC_TEMPENTITY, fVecOrigin);
 	write_byte(TE_EXPLOSION);
-	write_coord_f(vecOrigin[0]);
-	write_coord_f(vecOrigin[1]);
-	write_coord_f(vecOrigin[2] + 20.0);
+	write_coord_f(fVecOrigin[0]);
+	write_coord_f(fVecOrigin[1]);
+	write_coord_f(fVecOrigin[2] + 20.0);
 	write_short(g_szModels[2]);
 	write_byte(25);
 	write_byte(30);
 	write_byte(TE_EXPLFLAG_NONE);
 	message_end();
 	
-	message_begin_f(MSG_PAS, SVC_TEMPENTITY, vecOrigin);
+	message_begin_f(MSG_PAS, SVC_TEMPENTITY, fVecOrigin);
 	write_byte(TE_EXPLOSION);
-	write_coord_f(vecOrigin[0] + random_float(-64.0, 64.0));
-	write_coord_f(vecOrigin[1] + random_float(-64.0, 64.0));
-	write_coord_f(vecOrigin[2] + random_float(30.0, 35.0));
+	write_coord_f(fVecOrigin[0] + random_float(-64.0, 64.0));
+	write_coord_f(fVecOrigin[1] + random_float(-64.0, 64.0));
+	write_coord_f(fVecOrigin[2] + random_float(30.0, 35.0));
 	write_short(g_szModels[1]);
 	write_byte(30);
 	write_byte(30);
@@ -132,11 +132,11 @@ stock UTIL_MakeExplosionEffects(const Float:vecOrigin[3]) {
 	message_end();
 
 	for(new i; i < 3; i++) {
-		message_begin_f(MSG_PAS, SVC_TEMPENTITY, vecOrigin);
+		message_begin_f(MSG_PAS, SVC_TEMPENTITY, fVecOrigin);
 		write_byte(TE_SPRITE);
-		write_coord_f(vecOrigin[0] + random_float(-256.0, 256.0));
-		write_coord_f(vecOrigin[1] + random_float(-256.0, 256.0));
-		write_coord_f(vecOrigin[2] + random_float(-10.0, 10.0));
+		write_coord_f(fVecOrigin[0] + random_float(-256.0, 256.0));
+		write_coord_f(fVecOrigin[1] + random_float(-256.0, 256.0));
+		write_coord_f(fVecOrigin[2] + random_float(-10.0, 10.0));
 		write_short(g_szModels[i]);
 		write_byte(30);
 		write_byte(150);

--- a/addons/amxmodx/scripting/rt_sounds.sma
+++ b/addons/amxmodx/scripting/rt_sounds.sma
@@ -50,29 +50,29 @@ public plugin_precache() {
 	server_exec();
 }
 
-public rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_start(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(eMode) {
-		case MODE_REVIVE: { UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_REVIVE_START); }
-		case MODE_PLANT: { UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_PLANT_START); }
+		case MODE_REVIVE: { PlaybackSound(iEnt, iPlayer, iActivator, SECTION_REVIVE_START); }
+		case MODE_PLANT: { PlaybackSound(iEnt, iPlayer, iActivator, SECTION_PLANT_START); }
 	}
 }
 
-public rt_revive_loop_post(const iEnt, const id, const iActivator, const Float:timer, Modes:eMode) {
+public rt_revive_loop_post(const iEnt, const iPlayer, const iActivator, const Float:fTimer, Modes:eMode) {
 	switch(eMode) {
-		case MODE_REVIVE: { UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_REVIVE_LOOP); }
-		case MODE_PLANT: { UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_PLANT_LOOP); }
+		case MODE_REVIVE: { PlaybackSound(iEnt, iPlayer, iActivator, SECTION_REVIVE_LOOP); }
+		case MODE_PLANT: { PlaybackSound(iEnt, iPlayer, iActivator, SECTION_PLANT_LOOP); }
 	}
 }
 
-public rt_revive_end(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_end(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(eMode) {
 		case MODE_REVIVE: {
 			new Modes:iMode = Modes:get_entvar(iEnt, var_iuser3);
 			
 			if(iMode != MODE_PLANT)
-				UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_REVIVE_END);
+				PlaybackSound(iEnt, iPlayer, iActivator, SECTION_REVIVE_END);
 		}
-		case MODE_PLANT: { UTIL_PlaybackSound(iEnt, id, iActivator, SECTION_PLANT_END); }
+		case MODE_PLANT: { PlaybackSound(iEnt, iPlayer, iActivator, SECTION_PLANT_END); }
 	}
 }
 
@@ -119,24 +119,24 @@ public bool:ReadKeyValue(INIParser:iParser, const szKey[], const szValue[]) {
 	return true;
 }
 
-stock UTIL_PlaybackSound(const iEnt, const id, const iActivator, const sections_struct:iSoundSection) {
+stock PlaybackSound(const iEnt, const iPlayer, const iActivator, const sections_struct:iSoundSection) {
 	if(g_iSounds[iSoundSection]) {
 		if(g_eCvars[NEARBY_PLAYERS] == 2 || (g_eCvars[NEARBY_PLAYERS] && (iSoundSection == SECTION_REVIVE_END || iSoundSection == SECTION_PLANT_END)))
-			UTIL_PlaybackSoundNearbyPlayers(iEnt, g_szSounds[iSoundSection][random(g_iSounds[iSoundSection])]);
+			PlaybackSoundNearbyPlayers(iEnt, g_szSounds[iSoundSection][random(g_iSounds[iSoundSection])]);
 		else if(!g_eCvars[NEARBY_PLAYERS]) {
 			rg_send_audio(iActivator, g_szSounds[iSoundSection][random(g_iSounds[iSoundSection])]);
-			rg_send_audio(id, g_szSounds[iSoundSection][random(g_iSounds[iSoundSection])]);
+			rg_send_audio(iPlayer, g_szSounds[iSoundSection][random(g_iSounds[iSoundSection])]);
 		}
 	}
 }
 
-stock UTIL_PlaybackSoundNearbyPlayers(const id, const szSound[]) {
+stock PlaybackSoundNearbyPlayers(const iPlayer, const szSound[]) {
 	new iEnt = RT_NULLENT;
 
-	new Float:vOrigin[3];
-	get_entvar(id, var_vuser4, vOrigin);
+	new Float:fVecOrigin[3];
+	get_entvar(iPlayer, var_vuser4, fVecOrigin);
 	
-	while((iEnt = engfunc(EngFunc_FindEntityInSphere, iEnt, vOrigin, g_eCvars[SOUND_RADIUS])) > 0)
+	while((iEnt = engfunc(EngFunc_FindEntityInSphere, iEnt, fVecOrigin, g_eCvars[SOUND_RADIUS])) > 0)
 		if(ExecuteHam(Ham_IsPlayer, iEnt))
 			rg_send_audio(iEnt, szSound);
 }

--- a/addons/amxmodx/scripting/rt_timer.sma
+++ b/addons/amxmodx/scripting/rt_timer.sma
@@ -91,36 +91,36 @@ public plugin_init() {
 	g_eTimeData[START_TIME] = (1.0 - g_eTimeData[GLOBAL_TIME] / float(g_eTimeData[CEIL_TIME])) * 100.0;
 }
 
-public rt_revive_start(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_start(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(g_eCvars[TIMER_TYPE]) {
 		case 0: {
-			formatex(g_szTimer[id], charsmax(g_szTimer[]), TIMER_BEGIN);
+			formatex(g_szTimer[iPlayer], charsmax(g_szTimer[]), TIMER_BEGIN);
 
 			for(new i; i < floatround(g_eTimeData[GLOBAL_TIME]); i++)
-				add(g_szTimer[id], charsmax(g_szTimer[]), TIMER_ADD);
+				add(g_szTimer[iPlayer], charsmax(g_szTimer[]), TIMER_ADD);
 
-			add(g_szTimer[id], charsmax(g_szTimer[]), TIMER_END);
+			add(g_szTimer[iPlayer], charsmax(g_szTimer[]), TIMER_END);
 
-			DisplayHUDMessage(iActivator, id, eMode);
+			DisplayHudMessage(iPlayer, iActivator, eMode);
 		}
 		case 1: {
 			rg_send_bartime2(iActivator, g_eTimeData[CEIL_TIME], g_eTimeData[START_TIME]);
 
-			if(eMode == MODE_REVIVE && is_user_connected(id))
-				rg_send_bartime2(id, g_eTimeData[CEIL_TIME], g_eTimeData[START_TIME]);
+			if(eMode == MODE_REVIVE && is_user_connected(iPlayer))
+				rg_send_bartime2(iPlayer, g_eTimeData[CEIL_TIME], g_eTimeData[START_TIME]);
 		}
 	}
 }
 
-public rt_revive_loop_post(const iEnt, const id, const iActivator, const Float:timer, Modes:eMode) {
+public rt_revive_loop_post(const iEnt, const iPlayer, const iActivator, const Float:fTimer, Modes:eMode) {
 	if(!g_eCvars[TIMER_TYPE]) {
-		replace(g_szTimer[id], charsmax(g_szTimer[]), TIMER_REPLACE_SYMB, TIMER_REPLACE_WITH);
+		replace(g_szTimer[iPlayer], charsmax(g_szTimer[]), TIMER_REPLACE_SYMB, TIMER_REPLACE_WITH);
 
-		DisplayHUDMessage(iActivator, id, eMode);
+		DisplayHudMessage(iPlayer, iActivator, eMode);
 	}
 }
 
-public rt_revive_cancelled(const iEnt, const id, const iActivator, const Modes:eMode) {
+public rt_revive_cancelled(const iEnt, const iPlayer, const iActivator, const Modes:eMode) {
 	switch(g_eCvars[TIMER_TYPE]) {
 		case 0: {
 			if(iActivator != RT_NULLENT)
@@ -130,16 +130,16 @@ public rt_revive_cancelled(const iEnt, const id, const iActivator, const Modes:e
 			if(iActivator != RT_NULLENT)
 				rg_send_bartime(iActivator, 0);
 			
-			if(eMode == MODE_REVIVE && id != RT_NULLENT)
-				rg_send_bartime(id, 0);
+			if(eMode == MODE_REVIVE && iPlayer != RT_NULLENT)
+				rg_send_bartime(iPlayer, 0);
 		}
 	}
 }
 
-stock DisplayHUDMessage(const id, const dead, const Modes:eMode) {
+stock DisplayHudMessage(const iPlayer, const iActivator, const Modes:eMode) {
 	set_hudmessage(g_eHudData[eMode][COLOR_R], g_eHudData[eMode][COLOR_G], g_eHudData[eMode][COLOR_B],
 	g_eHudData[eMode][COORD_X], g_eHudData[eMode][COORD_Y], .holdtime = g_eTimeData[GLOBAL_TIME]);
-	ShowSyncHudMsg(id, g_iHudSyncObj, g_szTimer[dead]);
+	ShowSyncHudMsg(iActivator, g_iHudSyncObj, g_szTimer[iPlayer]);
 }
 
 public CreateCvars() {


### PR DESCRIPTION
fix: Error displaying messages in the chat.
fix: Fixed excessive work with the "PrepareArray" function.

refactor: The name of the function "UTIL_ResetEntityThink" has been changed to "ResetCorpseThink".
refactor: The name of the function "Corpse_Sprite_Think" has been changed to "CorpseSprite_Think".
refactor: The name of the variable "g_iPluginLoaded" has been changed to "g_iPlantingPluginID".
refactor: The type of the third argument of the "rt_creating_corpse_end" forward has been changed to Float.
refactor: The third argument (szFmtRules) of the "NotifyClient" function has been moved to the body of the function, as well as the tag for chat messages.
refactor: The prefix “UTIL” has been removed from the names of utility functions.
refactor: For vector variables, Vec has been added to the name.
refactor: The functions "rg_users_count" and "ResetCorpseThink" have undergone minor changes.

chore: The space character has been moved from the dictionary to the “NotifyClient” function.

docs: Function descriptions in .inc have been changed.
docs: The name HUD/DHUD has been changed to Hud/DHud in function names and descriptions.