### PR TITLE
Rollback to old functionality

### DIFF
--- a/addons/amxmodx/configs/rt_configs/rt_effects.cfg
+++ b/addons/amxmodx/configs/rt_configs/rt_effects.cfg
@@ -43,3 +43,13 @@ rt_corpse_sprite "sprites/rt/corpse_sprite2.spr"
 // Minimum: "0.1"
 // Maximum: "0.5"
 rt_sprite_scale "0.15"
+
+// Цвет трупа, который воскрешают(HEX)
+// The color of the corpse being resurrected(HEX)
+// Default: "#5da130"
+rt_revive_glow "#5da130"
+
+// Цвет трупа, который минируют(HEX)
+// The color of the corpse being planted(HEX)
+// Default: "#9b2d30"
+rt_planting_glow "#9b2d30"

--- a/addons/amxmodx/scripting/rt_core.sma
+++ b/addons/amxmodx/scripting/rt_core.sma
@@ -330,8 +330,8 @@ public MessageHook_ClCorpse() {
 
 	set_entvar(iEnt, var_modelindex, engfunc(EngFunc_ModelIndex, szModelPath));
 	set_entvar(iEnt, var_model, szModelPath);
-	set_entvar(iEnt, var_renderfx, kRenderFxDeadPlayer);
-	set_entvar(iEnt, var_renderamt, float(iPlayer));
+	//set_entvar(iEnt, var_renderfx, kRenderFxDeadPlayer);
+	//set_entvar(iEnt, var_renderamt, float(iPlayer));
 
 	set_entvar(iEnt, var_classname, DEAD_BODY_CLASSNAME);
 	set_entvar(iEnt, var_body, get_msg_arg_int(arg_body));


### PR DESCRIPTION
- rt_core.sma -> Rollback of kRenderFxDeadPlayer logic because support for 'cl_minmodels 1' should be done in a different way

- rt_effects.sma -> The cvars 'rt_revive_glow' and 'rt_planting_glow' have been restored because support for 'cl_minmodels 1' should be done in a different way