### PR TITLE
Add cvar `rt_corpse_model_mode`

### DIFF
--- a/addons/amxmodx/configs/rt_configs/rt_core.cfg
+++ b/addons/amxmodx/configs/rt_configs/rt_core.cfg
@@ -28,3 +28,7 @@ rt_search_radius "64.0"
 // Minimum: "0"
 // Maximum: "1"
 rt_force_fwd_mode "0"
+
+// Попробуйте установить 1, если трупы теряют нестандартную модель.
+// Try set this to 1 if corpses lose their custom model.
+rt_corpse_model_mode "0"

--- a/addons/amxmodx/scripting/include/rt_api.inc
+++ b/addons/amxmodx/scripting/include/rt_api.inc
@@ -9,7 +9,7 @@
 #endif
 #define _rt_api_included
 
-public stock const VERSION[] = "2.3.15";
+public stock const VERSION[] = "2.3.16";
 public stock const AUTHORS[] = "DEV-CS.RU Community";
 
 /**

--- a/addons/amxmodx/scripting/rt_core.sma
+++ b/addons/amxmodx/scripting/rt_core.sma
@@ -17,7 +17,8 @@ enum CVARS {
 	Float:ANTIFLOOD_TIME,
 	Float:CORPSE_TIME,
 	Float:SEARCH_RADIUS,
-	FORCE_FWD_MODE
+	FORCE_FWD_MODE,
+	CORPSE_MODEL_MODE
 };
 
 new g_eCvars[CVARS];
@@ -347,7 +348,15 @@ public MessageHook_ClCorpse() {
 	new szModelPath[MAX_RESOURCE_PATH_LENGTH];
 
 	if(!custom_player_models_get_path(iPlayer, szModelPath, charsmax(szModelPath))) {
-		formatex(szModelPath, charsmax(szModelPath), "models/player/%s/%s.mdl", g_szModel[iPlayer], g_szModel[iPlayer]);
+		if(!g_eCvars[CORPSE_MODEL_MODE]) {
+			formatex(szModelPath, charsmax(szModelPath), "models/player/%s/%s.mdl", g_szModel[iPlayer], g_szModel[iPlayer]);
+		}
+		else {
+			new szModel[64];
+			rh_update_user_info(iPlayer);
+			get_user_info(iPlayer, "model", szModel, charsmax(szModel));
+			formatex(szModelPath, charsmax(szModelPath), "models/player/%s/%s.mdl", szModel, szModel);
+		}
 		set_entvar(iEnt, var_body, get_msg_arg_int(arg_body));
 		set_entvar(iEnt, var_skin, get_entvar(iPlayer, var_skin));
 	}
@@ -458,6 +467,17 @@ public CreateCvars() {
 		true,
 		1.0),
 		g_eCvars[FORCE_FWD_MODE]
+	);
+	bind_pcvar_num(create_cvar(
+		"rt_corpse_model_mode",
+		"0",
+		FCVAR_NONE,
+		"Try set this to 1 if corpses lose their custom model.",
+		true,
+		0.0,
+		true,
+		1.0),
+		g_eCvars[CORPSE_MODEL_MODE]
 	);
 }
 


### PR DESCRIPTION
В текущей реализации защита от атаки подменой модели приводит к несовместимости с плагинами, заменяющими модели игроков, основанными на fakemeta/cstrike. В новой версии добавлен квар `rt_corpse_model_mode`, позволяющий переключить защиту в другой, совместимый режим. При этом, предположительно, этот режим может конфликтовать с другими плагинами, модифицирующими infobuffer игрока.

In the current implementation, protection against model substitution attacks leads to incompatibility with plugins that replace player models based on fakemeta/cstrike. The new version adds the `rt_corpse_model_mode` cvar, which allows switching the protection to another, compatible mode. However, presumably, this mode may conflict with other plugins that modify the player's infobuffer.